### PR TITLE
fix: use dynamic PORT to enable full Railway support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { cacheRoutes } from "./utils/cache-routes";
 dotenv.config();
 
 const app = express();
-const PORT = 4040;
+const PORT = process.env.PORT || 4040;
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
With this fix, the m3u8 proxy now runs correctly on Railway including support for HD-1, which currently does not function properly on Vercel due to stricter networking limitations.